### PR TITLE
Style overlap dimension properties

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -69,7 +69,7 @@ class Select extends Component {
 
     return (
       <TouchableWithoutFeedback onPress={this._onPress.bind(this)}>
-        <View ref={SELECT} style={[styles.container, style, dimensions ]}>
+        <View ref={SELECT} style={[styles.container, dimensions, style ]}>
           <Option style={ styleOption } styleText={ styleText }>{this.state.value}</Option>
         </View>
       </TouchableWithoutFeedback>


### PR DESCRIPTION
This modification allows you to customize the dimensions of the "select" regardless of the size that will be used within the overlay. Like this:

``` js
var styles = createStyles({
  select: {
    flex: 1,
    width: null,
  },
});
```
