### PR TITLE
Adding the option to style the items container via props

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ AppRegistry.registerComponent('App', () => App);
 | Property | Type | Default | Description |
 |-----------|--------|---------|--------------------------------------------|
 | overlayStyles | object | null | Styles to be applied on 'overlay' backdrop |
+| itemsStyles | object | null | Styles to be applied on 'overlay' backdrop |
 
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ AppRegistry.registerComponent('App', () => App);
 | Property | Type | Default | Description |
 |-----------|--------|---------|--------------------------------------------|
 | overlayStyles | object | null | Styles to be applied on 'overlay' backdrop |
-| itemsStyles | object | null | Styles to be applied on 'overlay' backdrop |
+| itemsStyles | object | null | Styles to be applied on 'items' dropdown |
 
 
 ## Demo

--- a/lib/items.js
+++ b/lib/items.js
@@ -45,7 +45,7 @@ class Items extends Component {
   }
 
   render() {
-    const { items, positionX, positionY, show, onPress, width, height } = this.props;
+    const { items, positionX, positionY, show, onPress, width, height, itemsStyles } = this.props;
 
     if (!show) {
       return null;
@@ -63,7 +63,7 @@ class Items extends Component {
     });
 
     return (
-      <View style={[styles.container]}>
+      <View style={[styles.container, itemsStyles]}>
         <AnimatedScrollView
           style={{ width: width - 2, height: this.state.height }}
           automaticallyAdjustContentInsets={false}

--- a/lib/optionList.js
+++ b/lib/optionList.js
@@ -23,8 +23,6 @@ class OptionList extends Component {
       pageX: 0,
       pageY: 0,
 
-      itemsStyle: {},
-
       positionX: 0,
       positionY: 0,
 

--- a/lib/optionList.js
+++ b/lib/optionList.js
@@ -23,6 +23,8 @@ class OptionList extends Component {
       pageX: 0,
       pageY: 0,
 
+      itemsStyle: {},
+
       positionX: 0,
       positionY: 0,
 
@@ -86,7 +88,8 @@ class OptionList extends Component {
       show
     } = this.state;
     const {
-      overlayStyles
+      overlayStyles,
+      itemsStyles
     } = this.props;
     return (
         <Overlay
@@ -100,6 +103,7 @@ class OptionList extends Component {
           positionX={positionX}
           positionY={positionY}
           width={width}
+          itemsStyles={itemsStyles}
           height={height}
           show={show}
           onPress={ this._onItemPress.bind(this) }/>


### PR DESCRIPTION
You can use this new feature to specify any style to the inner OptionList container.

Example:

````
<OptionList
  itemsStyles={{
    position: 'absolute',
    top: 10,
    left: 0
  }}
  ref="groupOptionList"
/>
````